### PR TITLE
Fdm tweak

### DIFF
--- a/ask21.xml
+++ b/ask21.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0"?>
+<!--<airplane mass="720" version="YASIM_VERSION_CURRENT">-->
 <airplane mass="720">
     <!-- Approach configuration -->
-    <approach speed="30" aoa="4" glide-angle="2.7">
+    <approach speed="35" aoa="4" glide-angle="8.2">
     </approach>
     <!-- Cruise configuration -->
-    <cruise speed="50" alt="5000" glide-angle="2.7">
+    <cruise speed="50" alt="5000" glide-angle="6.5">
     </cruise>
     <!-- pilot's eyepoint -->
     <cockpit x="2.5396" y="0" z="0.94214"/>
-    <fuselage ax="4.14514" ay="0.0" az="0.43618" bx="-3.76945" by="0.0" bz="0.73498" width="0.68" taper="0.28" midpoint="0.25" idrag="1"/>
+    <fuselage ax="4.14514" ay="0.0" az="0.43618" bx="-3.76945" by="0.0" bz="0.73498" width="0.68" taper="0.28" midpoint="0.25" idrag="2"/>
     <wing x="0.88522" y="0.370" z="0.73669" taper="0.15" incidence="4.0" twist="-2.5" length="8.334" chord="1.445" sweep="-5" dihedral="5">
         <stall aoa="24" width="12" peak="1.5"/>
         <flap0 start="0.43" end="0.97" lift="1.2" drag="1.15"/>

--- a/ask21.xml
+++ b/ask21.xml
@@ -28,20 +28,20 @@
     </wing>
     <hstab x="-3.67143" y="0.0" z="2.02347" taper="0.4" length="2" chord="0.861" sweep="0" incidence="8" effectiveness="2.8">
         <stall aoa="28" width="16" peak="1.5"/>
-        <flap0 start="0.0" end="0.89" lift="1.3" drag="1.15"/>
+        <flap0 start="0.0" end="0.89" lift="1.3" drag="1.25"/>
         <control-input axis="/controls/flight/elevator" control="FLAP0"/>
         <control-input axis="/controls/flight/elevator-trim" control="FLAP0"/>
-        <control-output control="FLAP0" prop="/surface-positions/elevator-pos-norm"/>
+        <control-output control="FLAP0" prop="/surface-positions/elevator-pos-norm" min="-4" max="4"/>
     </hstab>
     <vstab x="-3.5" y="0" z="0.76475" taper="0.75" effectiveness="2.5" length="1.2" chord="1.2" sweep="9">
-        <stall aoa="15" width="14" peak="1.5"/>
-        <flap0 start="0" end="0.88" lift="1.25" drag="1.2"/>
+        <stall aoa="25" width="14" peak="1.5"/>
+        <flap0 start="0" end="0.88" lift="1.5" drag="1.3"/>
         <control-input axis="/controls/flight/rudder" square="true" control="FLAP0" invert="true"/>
         <control-input axis="/controls/flight/rudder-trim" control="FLAP0" invert="true"/>
-        <control-output control="FLAP0" prop="/surface-positions/rudder-pos-norm" min="1" max="-1"/>
+        <control-output control="FLAP0" prop="/surface-positions/rudder-pos-norm" min="4" max="-4"/>
     </vstab>
     <!-- nose wheel -->
-    <gear x="3.25256" y="0" z="0.09253" compression="0.05" spring="1" damp="0.05" dfric="0.6" sfric="1"></gear>
+    <gear x="3.25256" y="0" z="0.09253" compression="0.01" spring="0.5" damp="0.05" dfric="0.6" sfric="1"></gear>
     <!-- main wheel-->
     <!--As on the ASK13, brake is tied to airbrake-->
     <gear x="0.99095" y="0" z="0.02933" compression="0.05" spring="0.5" damp="1" dfric="0.4" sfric="0.8">

--- a/ask21.xml
+++ b/ask21.xml
@@ -17,7 +17,7 @@
         <control-output control="FLAP0" side="left" prop="surface-positions/left-aileron-pos-norm"/>
         <control-output control="FLAP0" side="right" prop="surface-positions/right-aileron-pos-norm"/>
         <control-speed control="FLAP0" transition-time="0.5"/>
-        <spoiler start="0.34" end="0.44" lift="-4" drag="25.5"/>
+        <spoiler start="0.34" end="0.44" lift="-2" drag="35.5"/>
         <control-input axis="/controls/flight/aileron" control="FLAP0" split="true"/>
         <control-output control="FLAP0" side="left" prop="surface-positions/left-aileron-pos-norm"/>
         <control-output control="FLAP0" side="right" prop="surface-positions/right-aileron-pos-norm"/>


### PR DESCRIPTION
Changes to the FDM:

- Reduce glide performance
- Increase aileron drag (adverse yaw)
- Increase rudder effectiveness
- Limit elevator travel in an attempt to limit the maximum deflection even when trim is added. I'm not sure if this has worked.
- Made nose gear stiffer -- sometimes when bouncing the nose of the glider, the "ground" appears in the footwell of the glider meaning that the nose gear doesn't seem to be doing a good job