### PR TITLE
Fdm tweaks

### DIFF
--- a/ask21-set.xml
+++ b/ask21-set.xml
@@ -23,7 +23,7 @@ See AUTHORS.txt for credits
                 <path>Aircraft/ASK21/shadow-system.xml</path>
             </property-rule>
         </systems>
-        <aircraft-version>201702</aircraft-version>
+        <aircraft-version>201703</aircraft-version>
         <flight-model archive="y">yasim</flight-model>
         <aero archive="y">ask21</aero>
         <startup>
@@ -428,7 +428,7 @@ See AUTHORS.txt for credits
                 <binding>
                     <condition>
                         <greater-than-equals>
-                            <property>sim/model/door-positions/frontwin/position-norm</property> 
+                            <property>sim/model/door-positions/frontwin/position-norm</property>
                             <value>0.5</value>
                         </greater-than-equals>
                     </condition>

--- a/ask21-set.xml
+++ b/ask21-set.xml
@@ -136,7 +136,7 @@ See AUTHORS.txt for credits
             <config>
                 <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
                 <x-offset-m type="double">0.0</x-offset-m>
-                <y-offset-m type="double">0.92727</y-offset-m>
+                <y-offset-m type="double">1.04</y-offset-m>
                 <z-offset-m type="double">-2.51535</z-offset-m>
                 <pitch-offset-deg>-8</pitch-offset-deg>
                 <limits>

--- a/ask21.xml
+++ b/ask21.xml
@@ -59,8 +59,9 @@
     <weight x="1.72727" y="0.0" z="0.75498" mass-prop="/sim/weight[1]/weight-lb"/>
     <!--Tail ballast to enable spin with two pilots-->
     <weight x="-3.5" y="0.0" z="0.8" mass-prop="/sim/weight[2]/weight-lb"/>
-    <!--Distribute mass towards nose (cockpit weight etc.)-->
-    <ballast x="2" y="0" z=".5" mass="350"/>
+    <!--Distribute mass towards nose (cockpit weight etc.) and towards the wingtips to increase roll and yaw inertia -->
+    <ballast x="2" y="-10" z=".5" mass="175"/>
+    <ballast x="2" y="10" z=".5" mass="175"/>
     <!--FOR EASY GROUND HANDLING-->
     <!--Assiting gears for ground movement-->
     <gear x="0.99095" y="3" z="0.05" compression=".1"

--- a/ask21.xml
+++ b/ask21.xml
@@ -13,9 +13,8 @@
     <fuselage ax="4.14514" ay="0.0" az="0.43618" bx="-3.76945" by="0.0" bz="0.73498" width="0.68" taper="0.28" midpoint="0.25" idrag="1"/>
     <wing x="0.88522" y="0.370" z="0.73669" taper="0.15" incidence="2.0" twist="-2.5" length="8.334" chord="1.445" sweep="-5" dihedral="3.5">
         <stall aoa="23" width="8" peak="1.5"/>
-        <flap0 start="0.43" end="0.97" lift="1.3" drag="1.7"/>
-        <spoiler start="0.34" end="0.44" lift="-4" drag="75.5"/>
-<!-- drag="35.5 -->
+        <flap0 start="0.43" end="0.97" lift="1.15" drag="3.2"/>
+        <spoiler start="0.34" end="0.44" lift="-4.5" drag="75.5"/>
         <control-input axis="/controls/flight/aileron" control="FLAP0" split="true"/>
         <control-output control="FLAP0" side="left" prop="surface-positions/left-aileron-pos-norm"/>
         <control-output control="FLAP0" side="right" prop="surface-positions/right-aileron-pos-norm"/>
@@ -44,7 +43,7 @@
     <!-- main wheel-->
     <!--As on the ASK13, brake is tied to airbrake-->
     <gear x="0.99095" y="0" z="0.02933" compression="0.05" spring="0.5" damp="1" dfric="0.4" sfric="0.8">
-        <control-input axis="/controls/engines/engine/throttle" control="BRAKE" src0="0" src1="0.15" dst0="1" dst1="0"/>
+        <control-input axis="/controls/engines/engine/throttle" control="BRAKE" src0="0" src1="0.1" dst0="1" dst1="0"/>
         <control-input axis="/controls/gear/brake-parking" control="BRAKE"/>
     </gear>
     <!-- Tail wheel -->


### PR DESCRIPTION
I had a couple of instructors at my club test-fly the ASK21 and I've made some tweaks to the flight model and the view position based on their feedback.

- raised the view to make the nose look lower in normal flight (before you couldn't see the tug when aerotowing at 60 knots if you allowed its wheels to touch the horizon)
- reduced aileron sensitivity as it was judged to be too high
- increased aileron drag (adverse yaw)
- made the airbrakes more efficient (videos showing 6-8 knots down with airbrake on landing)
- made the wheel brake to kick in on a smaller portion of airbrake travel
- distributed some mass towards the wingtips to give the aircraft more yaw and roll inertia when applying the controls suddenly